### PR TITLE
Fix bug with NullTime and parsing DATE from database.

### DIFF
--- a/app/db/db.go
+++ b/app/db/db.go
@@ -17,6 +17,10 @@ func OpenConnection() error {
 	dsn.Addr = os.Getenv(env.DBHostKey)
 	dsn.DBName = os.Getenv(env.DBNameKey)
 
+	// Make sure we can parse DATE into time.Time
+	dsn.Params = make(map[string]string)
+	dsn.Params["parseTime"] = "true"
+
 	pool, err := sqlx.Connect("mysql", dsn.FormatDSN())
 	if err != nil {
 		return err

--- a/app/models/job/job.go
+++ b/app/models/job/job.go
@@ -1,4 +1,4 @@
-package models
+package job
 
 import (
 	"database/sql"
@@ -9,8 +9,6 @@ import (
 type Id string
 type Country string
 type CountryCode string
-type DateAdded *sql.NullTime // Time is optional, must check if [DateAdded.Valid] before using
-type HasExpired int64        // Boolean type, value 0 for false, 1 for true.
 type Board string
 type Description string
 type Title string
@@ -26,8 +24,8 @@ type Job struct {
 	Id           Id           `db:"_id"`
 	Country      Country      `db:"country"`
 	CountryCode  CountryCode  `db:"country_code"`
-	DateAdded    DateAdded    `db:"date_added"`
-	HasExpired   HasExpired   `db:"has_expired"`
+	DateAdded    sql.NullTime `db:"date_added"` // Time is optional, must check if [DateAdded.Valid] before using
+	HasExpired   bool         `db:"has_expired"`
 	Board        Board        `db:"job_board"`
 	Description  Description  `db:"job_description"`
 	Title        Title        `db:"job_title"`


### PR DESCRIPTION
**Changes**
- Fix bug with null time and non-null time. We weren't parsing it correctly.
- Also just moved into its own job folder.
- `Job` struct has inline types for better scanning.

Testing (bruh we need unit tests)
```
	// Testing GetJobById in `server.go`
	job_id, err := job.GetJobById("0009a802e4e7e4353b390125ae16e04a")
	if err != nil {
		// Log error and print to stderr.
		errLogger.Printf("Error: Failed to find job %v", err)
		log.Printf("Error: Failed to find job %v", err)
	} else {
		log.Print(job_id)
	}

	// Testing GetJobs in `server.go`
	numberOfJobs := 20
	jobs, err := job.GetJobs(numberOfJobs)
	if err != nil {
		// Log error and print to stderr.
		errLogger.Printf("Error: Failed to find %d jobs %v", numberOfJobs, err)
		log.Printf("Error: Failed to find %d jobs %v", numberOfJobs, err)
	} else {
		log.Print(jobs)
	}
```