### PR TITLE
Added employer test data + script to add into employers table.

### DIFF
--- a/data/employers-test.csv
+++ b/data/employers-test.csv
@@ -1,0 +1,11 @@
+name,works_at
+Jacqueline Combs,1
+Jorden Benson,2
+Hannah Vaughn,3
+Dominique Watson,4
+Stefanie Ramirez,1
+Fatema Mata,3
+Peggy Xiong,3
+John Smith,2
+John Smith,2
+John Smith,3

--- a/scripts/import_employers_data.py
+++ b/scripts/import_employers_data.py
@@ -1,0 +1,32 @@
+from db import get_db_connection, populate_table
+import os
+
+def create_table():
+    query = """
+    CREATE TABLE IF NOT EXISTS employers (
+    _id INT PRIMARY KEY AUTO_INCREMENT,
+    name VARCHAR(225),
+    works_at INT,
+    FOREIGN KEY (works_at) REFERENCES companies (_id) ON DELETE CASCADE
+    )
+    """
+    db_cxn = get_db_connection(True)
+    db_cxn.cursor().execute(query)
+
+
+def drop_table():
+    db_cxn = get_db_connection(True)
+    db_cxn.cursor().execute("DROP TABLE IF EXISTS employers")
+
+
+def populate_employers_data():
+    drop_table()
+    create_table()
+    # Only populates employer test data in testing environment.
+    if os.getenv("BREAD_ENV") == "testing":
+        data_src = 'data/employers-test.csv'
+        populate_table('employers', data_src)
+
+
+if __name__ == '__main__':
+    populate_employers_data()


### PR DESCRIPTION
**Changes**
- 10 test employers that test for duplicate naming (across companies and in same company), no employer for existing company, and basic cases.
- Boilerplate script to add data to the `employers` table.