### PR TITLE
Fixed job model missing company_id column

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,32 +2,52 @@
 
 
 [[projects]]
+  digest = "1:10d6aa505e0698b315d19aa9fe91bcf8e7cb3fa93a7acca41f1b41c6e669050b"
   name = "github.com/go-chi/chi"
-  packages = [".","middleware"]
+  packages = [
+    ".",
+    "middleware",
+  ]
+  pruneopts = "UT"
   revision = "2db61557f36b2f4caa20ce6ef50e98bac0f7fce5"
   version = "v4.0.3"
 
 [[projects]]
+  digest = "1:a3af33fd30536d9c5a7b6ad542390919e57c1125097a194c7b3d9904109a0611"
   name = "github.com/go-sql-driver/mysql"
   packages = ["."]
+  pruneopts = "UT"
   revision = "17ef3dd9d98b69acec3e85878995ada9533a9370"
   version = "v1.5.0"
 
 [[projects]]
+  digest = "1:6c41d4f998a03b6604227ccad36edaed6126c397e5d78709ef4814a1145a6757"
   name = "github.com/jmoiron/sqlx"
-  packages = [".","reflectx"]
+  packages = [
+    ".",
+    "reflectx",
+  ]
+  pruneopts = "UT"
   revision = "d161d7a76b5661016ad0b085869f77fd410f3e6a"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:ecd9aa82687cf31d1585d4ac61d0ba180e42e8a6182b85bd785fcca8dfeefc1b"
   name = "github.com/joho/godotenv"
   packages = ["."]
+  pruneopts = "UT"
   revision = "23d116af351c84513e1946b527c88823e476be13"
   version = "v1.3.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "04f8660ce022a958f96c4e149516712329ed72c808316314dae11b80dafb7d1c"
+  input-imports = [
+    "github.com/go-chi/chi",
+    "github.com/go-chi/chi/middleware",
+    "github.com/go-sql-driver/mysql",
+    "github.com/jmoiron/sqlx",
+    "github.com/joho/godotenv",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/app/models/job/job.go
+++ b/app/models/job/job.go
@@ -7,6 +7,7 @@ import (
 )
 
 type Id string
+type CompanyId int
 type Country string
 type CountryCode string
 type Board string
@@ -24,6 +25,7 @@ type Jobs []*Job
 // TODO(kallentu): Make component (usable) struct for Job.
 type Job struct {
 	Id           Id           `db:"_id"`
+	CompanyId    CompanyId    `db:"company_id"`
 	Country      Country      `db:"country"`
 	CountryCode  CountryCode  `db:"country_code"`
 	DateAdded    sql.NullTime `db:"date_added"` // Time is optional, must check if [DateAdded.Valid] before using


### PR DESCRIPTION
I'm guessing job model wasn't updated when we added `company_id` as a foreign key to the jobs table, so the `/jobs` endpoint was failing with `missing destination name company_id in *job.Job`. 
* Added company_id to job model
* Not sure why Gopkg.lock changed but if y'all wanna lmk if its ok that would be coolio.