### PR TITLE
Added API support for candidate swipe right and swipe left

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,24 @@ POST `/candidates/login`
 }
 ```
 
+### Candidate Likes Job (Swipes Right)
+POST `/candidates/jobs/{job_id}/like`
+##### Request Header
+```json
+{
+  user_id: Int
+}
+```
+
+### Candidate Dislikes Job (Swipes Left)
+POST `/candidates/jobs/{job_id}/dislike`
+##### Request Header
+```json
+{
+  user_id: Int
+}
+```
+
 ### Get jobs not seen for candidate by ID
 GET `/candidates/jobs/candidate/{candidate_id}`
 

--- a/app/handlers/candidateDislikesJobHandler/candidateDislikesJobHandler.go
+++ b/app/handlers/candidateDislikesJobHandler/candidateDislikesJobHandler.go
@@ -1,0 +1,31 @@
+package candidateDislikesJobHandler
+
+import (
+	"github.com/go-chi/chi"
+	"github.com/jasonjchu/bread/app/models/candidate"
+	"github.com/jasonjchu/bread/app/models/job"
+	"github.com/jasonjchu/bread/app/services/candidateDislikesJobService"
+	"net/http"
+	"strconv"
+)
+
+const RouteURL string = "/dislike"
+
+func Handler(w http.ResponseWriter, r *http.Request) {
+	cid := r.Header.Get("user_id")
+	candidateId, err := strconv.Atoi(cid)
+	if err != nil {
+		http.Error(w, err.Error(), 400)
+	}
+	jid := chi.URLParam(r, "job_id")
+	req := candidateDislikesJobService.Request{
+		CandidateId: candidate.Id(candidateId),
+		JobId:       job.Id(jid),
+	}
+	err = candidateDislikesJobService.Exec(req)
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+	w.Write([]byte(""))
+}

--- a/app/handlers/candidateLikesJobHandler/candidateLikesJobHandler.go
+++ b/app/handlers/candidateLikesJobHandler/candidateLikesJobHandler.go
@@ -1,0 +1,31 @@
+package candidateLikesJobHandler
+
+import (
+	"github.com/go-chi/chi"
+	"github.com/jasonjchu/bread/app/models/candidate"
+	"github.com/jasonjchu/bread/app/models/job"
+	"github.com/jasonjchu/bread/app/services/candidateLikesJobService"
+	"net/http"
+	"strconv"
+)
+
+const RouteURL string = "/like"
+
+func Handler(w http.ResponseWriter, r *http.Request) {
+	cid := r.Header.Get("user_id")
+	candidateId, err := strconv.Atoi(cid)
+	if err != nil {
+		http.Error(w, err.Error(), 400)
+	}
+	jid := chi.URLParam(r, "job_id")
+	req := candidateLikesJobService.Request{
+		CandidateId: candidate.Id(candidateId),
+		JobId:       job.Id(jid),
+	}
+	err = candidateLikesJobService.Exec(req)
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+	w.Write([]byte(""))
+}

--- a/app/handlers/getJobsForCandidatesHandler/getJobsForCandidatesHandler.go
+++ b/app/handlers/getJobsForCandidatesHandler/getJobsForCandidatesHandler.go
@@ -8,7 +8,7 @@ import (
 )
 
 // TODO: Change from passing the route in the param url to in the request header
-const RouteURL string = "/{id}"
+const RouteURL string = "/candidate/{id}"
 const jobLimit int = 200
 
 func Handler(w http.ResponseWriter, r *http.Request) {

--- a/app/models/candidateSeenJob/candidateSeenJob.go
+++ b/app/models/candidateSeenJob/candidateSeenJob.go
@@ -1,0 +1,28 @@
+package candidateSeenJob
+
+import (
+	"github.com/jasonjchu/bread/app/db"
+	"github.com/jasonjchu/bread/app/models/candidate"
+	"github.com/jasonjchu/bread/app/models/job"
+)
+
+type CandidateSeenJob struct {
+	CandidateId candidate.Id `db:"cid"`
+	JobId       job.Id       `db:"jid"`
+	Liked       bool         `dbb:"liked"`
+}
+
+func insertCandidateSeenJob(cid candidate.Id, jid job.Id, liked bool) error {
+	pool := db.Pool
+	insertQuery := `INSERT INTO candidateSeenJob (cid, jid, liked) VALUES (?, ?, ?)`
+	_, err := pool.Exec(insertQuery, cid, jid, liked)
+	return err
+}
+
+func InsertCandidateLikesJob(cid candidate.Id, jid job.Id) error {
+	return insertCandidateSeenJob(cid, jid, true)
+}
+
+func InsertCandidateDislikesJob(cid candidate.Id, jid job.Id) error {
+	return insertCandidateSeenJob(cid, jid, false)
+}

--- a/app/routes/routes.go
+++ b/app/routes/routes.go
@@ -2,6 +2,8 @@ package routes
 
 import (
 	"github.com/go-chi/chi"
+	"github.com/jasonjchu/bread/app/handlers/candidateDislikesJobHandler"
+	"github.com/jasonjchu/bread/app/handlers/candidateLikesJobHandler"
 	"github.com/jasonjchu/bread/app/handlers/candidateLoginHandler"
 	"github.com/jasonjchu/bread/app/handlers/candidateRegisterHandler"
 	"github.com/jasonjchu/bread/app/handlers/employerLoginHandler"
@@ -43,8 +45,16 @@ func initCandidateRoutes(r chi.Router) {
 	r.Route("/candidates", func(r chi.Router) {
 		r.Post(candidateRegisterHandler.RouteURL, candidateRegisterHandler.Handler)
 		r.Post(candidateLoginHandler.RouteURL, candidateLoginHandler.Handler)
-		r.Route("/jobs/candidate", func(r chi.Router) {
+
+		r.Route("/jobs", func(r chi.Router) {
+			// GET JOBS
 			r.Get(getJobsForCandidatesHandler.RouteURL, getJobsForCandidatesHandler.Handler)
+
+			// LIKE AND DISLIKE JOBS
+			r.Route("/{job_id}", func(r chi.Router) {
+				r.Post(candidateLikesJobHandler.RouteURL, candidateLikesJobHandler.Handler)
+				r.Post(candidateDislikesJobHandler.RouteURL, candidateDislikesJobHandler.Handler)
+			})
 		})
 	})
 }

--- a/app/services/candidateDislikesJobService/candidateDislikesJobService.go
+++ b/app/services/candidateDislikesJobService/candidateDislikesJobService.go
@@ -1,0 +1,16 @@
+package candidateDislikesJobService
+
+import (
+	"github.com/jasonjchu/bread/app/models/candidate"
+	"github.com/jasonjchu/bread/app/models/candidateSeenJob"
+	"github.com/jasonjchu/bread/app/models/job"
+)
+
+type Request struct {
+	CandidateId candidate.Id `json:"candidate_id"`
+	JobId       job.Id       `json:"job_id"`
+}
+
+func Exec(req Request) error {
+	return candidateSeenJob.InsertCandidateDislikesJob(req.CandidateId, req.JobId)
+}

--- a/app/services/candidateLikesJobService/candidateLikesJobService.go
+++ b/app/services/candidateLikesJobService/candidateLikesJobService.go
@@ -1,0 +1,16 @@
+package candidateLikesJobService
+
+import (
+	"github.com/jasonjchu/bread/app/models/candidate"
+	"github.com/jasonjchu/bread/app/models/candidateSeenJob"
+	"github.com/jasonjchu/bread/app/models/job"
+)
+
+type Request struct {
+	CandidateId candidate.Id `json:"candidate_id"`
+	JobId       job.Id       `json:"job_id"`
+}
+
+func Exec(req Request) error {
+	return candidateSeenJob.InsertCandidateLikesJob(req.CandidateId, req.JobId)
+}


### PR DESCRIPTION
Added handlers, services, and SQL queries to handle candidates swiping right (liking) and
swiping left (disliking) a job.

Original table:
<img width="429" alt="Screen Shot 2020-04-03 at 12 40 14 AM" src="https://user-images.githubusercontent.com/26018804/78324956-3bd0ff80-7544-11ea-9da4-822919ea6843.png">

Candidate `3` likes job `0d9a01619f1ecafbe020974d3b183687` 
<img width="428" alt="Screen Shot 2020-04-03 at 12 40 20 AM" src="https://user-images.githubusercontent.com/26018804/78324970-47242b00-7544-11ea-8c18-38adf4d9f8ca.png">

Candidate `5` dislikes job `0d9a01619f1ecafbe020974d3b183687` 
<img width="430" alt="Screen Shot 2020-04-03 at 12 40 25 AM" src="https://user-images.githubusercontent.com/26018804/78324980-4ee3cf80-7544-11ea-9055-12dc42d8b8bd.png">
